### PR TITLE
Update references to multicore compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ OPAM repo for OCaml multicore development
 
 ```
 $ opam remote add multicore https://github.com/ocamllabs/multicore-opam.git
-$ opam switch 4.02.2+multicore 
+$ opam switch 4.04.2+multicore
 ```

--- a/compilers/4.02.2+multicore/4.02.2+multicore.comp
+++ b/compilers/4.02.2+multicore/4.02.2+multicore.comp
@@ -1,6 +1,6 @@
 opam-version: "1"
 version: "4.02.2"
-src: "https://github.com/ocamllabs/ocaml-multicore/archive/master.tar.gz"
+src: "https://github.com/ocamllabs/ocaml-multicore/archive/4.02.2.tar.gz"
 build: [
   ["./configure" "-prefix" "%{prefix}%" "-with-debug-runtime"]
   ["%{make}%" "world.opt"]

--- a/compilers/4.04.2+multicore/4.04.2+multicore.comp
+++ b/compilers/4.04.2+multicore/4.04.2+multicore.comp
@@ -1,0 +1,12 @@
+opam-version: "1"
+version: "4.04.2"
+src: "https://github.com/ocamllabs/ocaml-multicore/archive/master.tar.gz"
+build: [
+  ["./configure" "-prefix" "%{prefix}%" "-with-debug-runtime"]
+  ["%{make}%" "world.opt"]
+  ["%{make}%" "install"]
+]
+packages: ["base-unix" "base-bigarray" "base-threads"]
+env: [
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+]

--- a/compilers/4.04.2+multicore/4.04.2+multicore.descr
+++ b/compilers/4.04.2+multicore/4.04.2+multicore.descr
@@ -1,0 +1,1 @@
+OCaml 4.04.2, with support for multicore


### PR DESCRIPTION
This pull updates references to multicore compilers due to the master branch of [ocamllabs/ocaml-multicore](https://github.com/ocamllabs/ocaml-multicore) now being version 4.04.2 of the multicore compiler.

I'm not sure if any updates to `urls.txt` are required.