### PR TITLE
Add the OMake 0.10.3 package with patches for OCaml 4.06.1 +multicore.

### DIFF
--- a/packages/omake/omake.0.10.3+multicore-1/opam
+++ b/packages/omake/omake.0.10.3+multicore-1/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+name: "omake"
+maintainer: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+authors: [
+  "Aleksey Nogin"
+  "Jason Hickey"
+  "Gerd Stolpmann"
+]
+
+license: "GPL2"
+dev-repo: "https://github.com/ocaml-omake/omake.git"
+homepage: "http://projects.camlcity.org/projects/omake.html"
+bug-reports: "https://github.com/ocaml-omake/issues"
+
+build: [
+  ["./configure" "-prefix" "%{prefix}%"]
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  [ "rm" "-f" "%{prefix}%/bin/omake" ]
+  [ "rm" "-f" "%{prefix}%/bin/osh" ]
+  [ "rm" "-rf" "%{prefix}%/lib/omake" ]
+]
+
+depends: ["ocamlfind"]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/omake/omake.0.10.3+multicore-1/url
+++ b/packages/omake/omake.0.10.3+multicore-1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/jhwoodyatt/omake/archive/omake-0.10.3+multicore-1.zip"
+checksum: "c7423be1daf9e28c31ec9f3a4bf9b841"


### PR DESCRIPTION
Patched for the following reasons:
- Do not use 'effect' as a variable name.
- Use the new C primitive API required by the multicore variant.